### PR TITLE
chore: build before stage publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Publish
         run: pnpm stage publish --no-git-checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,5 +35,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm install && npx playwright install
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Run Test
         run: pnpm run test

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev": "rslib -w",
     "lint": "rslint && prettier -c .",
     "lint:write": "rslint --fix && prettier -w .",
-    "prepare": "simple-git-hooks && pnpm run build",
+    "prepare": "simple-git-hooks",
     "test": "playwright test",
     "bump": "npx bumpp"
   },


### PR DESCRIPTION
## Summary

- Build packages in the release workflow before `pnpm stage publish`.
- Remove duplicate build commands from `scripts.prepare` where present.

## Validation

- Verified staged publish workflows have a preceding `pnpm build`.
- Ran `git diff --check`.