### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@rsbuild/plugin-mdx",
   "version": "1.1.3",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-mdx",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-mdx#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-mdx/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add npm homepage metadata pointing to the repository README
- add bugs.url metadata pointing to the repository issue tracker
- leave runtime code, dependencies, exports, and package version unchanged

## Validation
- node -e "const p=require('./package.json'); if(p.homepage!=='https://github.com/rstackjs/rsbuild-plugin-mdx#readme') throw new Error('bad homepage'); if(p.bugs?.url!=='https://github.com/rstackjs/rsbuild-plugin-mdx/issues') throw new Error('bad bugs'); console.log(JSON.stringify({name:p.name, version:p.version, homepage:p.homepage, bugs:p.bugs, repository:p.repository}, null, 2));"
- npm view @rsbuild/plugin-mdx@1.1.3 name version repository homepage bugs license --json
- npm pack --dry-run --ignore-scripts --json .
- pnpm exec prettier -c package.json
- pnpm run lint
- pnpm run build
- git diff --check