### PR TITLE
chore: reuse shared test utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@rsbuild/plugin-vue": "^2.0.0",
     "@rslib/core": "^0.23.1",
     "@rslint/core": "^0.6.4",
+    "@rstackjs/test-utils": "^0.2.0",
     "@rstest/core": "^0.11.1",
     "@rstest/playwright": "^0.11.1",
     "@types/node": "^24.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@rslint/core':
         specifier: ^0.6.4
         version: 0.6.4
+      '@rstackjs/test-utils':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@rstest/core':
         specifier: ^0.11.1
         version: 0.11.1
@@ -590,6 +593,9 @@ packages:
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
+
+  '@rstackjs/test-utils@0.2.0':
+    resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
 
   '@rstest/core@0.11.1':
     resolution: {integrity: sha512-9iJnDrM/zYuHyk1//CMr/Jer2XughgN3fYagGb1YWpMLUke+E+WXlUPgACwf7OkmIB47/TttbLFK+4zwGDNOFg==}
@@ -2093,6 +2099,8 @@ snapshots:
       react-refresh: 0.18.0
     optionalDependencies:
       '@rspack/core': 2.1.3(@swc/helpers@0.5.23)
+
+  '@rstackjs/test-utils@0.2.0': {}
 
   '@rstest/core@0.11.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
+  - '@rstackjs/test-utils@0.2.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,4 +6,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
-  - '@rstackjs/test-utils@0.2.0'
+  - '@rstackjs/*'

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,1 +1,0 @@
-export { getRandomPort } from '@rstackjs/test-utils';

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,14 +1,1 @@
-const portMap = new Map();
-
-export function getRandomPort(
-  defaultPort = Math.ceil(Math.random() * 30000) + 15000,
-) {
-  let port = defaultPort;
-  while (true) {
-    if (!portMap.get(port)) {
-      portMap.set(port, 1);
-      return port;
-    }
-    port++;
-  }
-}
+export { getRandomPort } from '@rstackjs/test-utils';

--- a/test/preact/rsbuild.config.ts
+++ b/test/preact/rsbuild.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/preact/rsbuild.config.ts
+++ b/test/preact/rsbuild.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginMdx } from '@rsbuild/plugin-mdx';
 import { pluginPreact } from '@rsbuild/plugin-preact';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [

--- a/test/react-hmr/rsbuild.config.ts
+++ b/test/react-hmr/rsbuild.config.ts
@@ -6,6 +6,6 @@ import { getRandomPort } from '../helper';
 export default defineConfig({
   plugins: [pluginReact(), pluginMdx()],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/react-hmr/rsbuild.config.ts
+++ b/test/react-hmr/rsbuild.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginMdx } from '@rsbuild/plugin-mdx';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [pluginReact(), pluginMdx()],

--- a/test/react/rsbuild.config.ts
+++ b/test/react/rsbuild.config.ts
@@ -6,6 +6,6 @@ import { getRandomPort } from '../helper';
 export default defineConfig({
   plugins: [pluginReact(), pluginMdx()],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/react/rsbuild.config.ts
+++ b/test/react/rsbuild.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginMdx } from '@rsbuild/plugin-mdx';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [pluginReact(), pluginMdx()],

--- a/test/svgr/rsbuild.config.ts
+++ b/test/svgr/rsbuild.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginMdx } from '@rsbuild/plugin-mdx';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [

--- a/test/svgr/rsbuild.config.ts
+++ b/test/svgr/rsbuild.config.ts
@@ -15,6 +15,6 @@ export default defineConfig({
     pluginMdx(),
   ],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/vue/rsbuild.config.ts
+++ b/test/vue/rsbuild.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/vue/rsbuild.config.ts
+++ b/test/vue/rsbuild.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginMdx } from '@rsbuild/plugin-mdx';
 import { pluginVue } from '@rsbuild/plugin-vue';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [


### PR DESCRIPTION
This PR replaces the local random-port helper with `@rstackjs/test-utils` so test servers verify port availability through the shared ecosystem implementation. Rsbuild configs now await the asynchronous helper.